### PR TITLE
remove undefined edge label protocol

### DIFF
--- a/kubesurveyor/main.py
+++ b/kubesurveyor/main.py
@@ -200,7 +200,6 @@ def visualize():
                         dot_root.edge(
                             service_name,
                             container_name + existing_pods[pod],
-                            label=proto,
                         )
                 dot_pods.subgraph(dot_pod)
     # push the subgraphs to the dot_root


### PR DESCRIPTION
Removing `proto` labes from service to pod edges as it's not scrapped and is incompatible with the current yaml format.